### PR TITLE
add events 38c3 and why2025

### DIFF
--- a/config.json
+++ b/config.json
@@ -146,6 +146,7 @@
     {"name": "MRMCD 2023 - Meta Rhein Main Community Days 2023, Darmstadt", "angels": 97, "link": "https://2023.mrmcd.net/"},
     {"name": "37C3 - 37. Chaos Communication Congress, Hamburg", "angels": 4868, "link": "https://events.ccc.de/congress/2023/infos/startpage.html"},
     {"name": "GPN22 - 22. Gulaschprogrammiernacht (2024), Karlsruhe", "angels": 874, "link": "https://entropia.de/GPN22"},
-    {"name": "38C3 - 38. Chaos Communication Congress, Hamburg", "angels": 5751, "link": "https://events.ccc.de/congress/2024/infos/startpage.html"}
+    {"name": "38C3 - 38. Chaos Communication Congress, Hamburg", "angels": 5751, "link": "https://events.ccc.de/congress/2024/infos/startpage.html"},
+    {"name": "WHY2025 - What Hackers Yearn, Geestmerambacht", "angels": 1866, "link": "https://why2025.org/"}
   ]
 }

--- a/config.json
+++ b/config.json
@@ -145,6 +145,7 @@
     {"name": "cccamp23 - Chaos Communication Camp 2023", "angels": 1767, "link": "https://events.ccc.de/camp/2023/infos/"},
     {"name": "MRMCD 2023 - Meta Rhein Main Community Days 2023, Darmstadt", "angels": 97, "link": "https://2023.mrmcd.net/"},
     {"name": "37C3 - 37. Chaos Communication Congress, Hamburg", "angels": 4868, "link": "https://events.ccc.de/congress/2023/infos/startpage.html"},
-    {"name": "GPN22 - 22. Gulaschprogrammiernacht (2024), Karlsruhe", "angels": 874, "link": "https://entropia.de/GPN22"}
+    {"name": "GPN22 - 22. Gulaschprogrammiernacht (2024), Karlsruhe", "angels": 874, "link": "https://entropia.de/GPN22"},
+    {"name": "38C3 - 38. Chaos Communication Congress, Hamburg", "angels": 5751, "link": "https://events.ccc.de/congress/2024/infos/startpage.html"}
   ]
 }


### PR DESCRIPTION

- numbers for 38c3 are from the orga wiki.
- why2025 numbers from here: https://stats.why2025.org/d/dertuq4ggz7cwf/why20253a-angels?orgId=1&from=now-90d&to=now&timezone=browser

<img width="1273" height="85" alt="grafik" src="https://github.com/user-attachments/assets/47b70594-e3a1-4e2d-ba69-1040b66c9054" />
